### PR TITLE
Fix issue: displaying stale distances while calculating new distances…

### DIFF
--- a/frontend/src/components/Listings/ListingsIndex.js
+++ b/frontend/src/components/Listings/ListingsIndex.js
@@ -40,6 +40,7 @@ const ListingsIndex = ({localLatLon, filter=null, isMapsAPILoaded}) => {
 
 	useEffect(() => {
 		window.scrollTo(0, 0);
+		setDistancesArray([]);
 	}, [filter])
 
 	let destinations = filteredListings.map(listing => {
@@ -82,30 +83,17 @@ const ListingsIndex = ({localLatLon, filter=null, isMapsAPILoaded}) => {
 	} else {
 		listingCards = [];
 		if(filteredListings.length !== 0){
-			if(!filter){
-				for(let i = 1; i <= numTestListings; i++) {
-					listingCards.push(
-						<ListingsIndexCard 
-							key={filteredListings[((i - 1) % filteredListings.length)].title}
-							distance={distancesArray[i - 1]} 
-							filter={filter} 
-							listing={filteredListings[(i - 1) % filteredListings.length]} 
-							num={i} 
-						/>
-					)
-				}
-			} else {
-				for(let i = 1; i <= filteredListings.length; i++) {
-					listingCards.push(
-						<ListingsIndexCard 
-							key={filteredListings[((i - 1) % filteredListings.length)].title}
-							distance={distancesArray[i - 1]} 
-							filter={filter} 
-							listing={filteredListings[(i - 1) % filteredListings.length]} 
-							num={i} 
-						/>
-					)
-				}
+			let limit = filter ? filteredListings.length : numTestListings;
+			for(let i = 1; i <= limit; i++) {
+				listingCards.push(
+					<ListingsIndexCard 
+						key={filteredListings[((i - 1) % filteredListings.length)].title}
+						distance={distancesArray[i - 1]} 
+						filter={filter} 
+						listing={filteredListings[(i - 1) % filteredListings.length]} 
+						num={i} 
+					/>
+				)
 			}
 		}
 	}

--- a/frontend/src/components/Listings/ListingsIndexCard.js
+++ b/frontend/src/components/Listings/ListingsIndexCard.js
@@ -9,7 +9,7 @@ export default function ListingsIndexCard ({distance, listing, num, filter}) {
 		return (twoDigit === oneDigit + '0') ? oneDigit : twoDigit;
 	}
 	return (
-		<motion.div key={num.toString() + filter} initial={{opacity:0.0}} animate={{opacity:1, transition:{delay:(num) * 0.035, duration: 0.2, ease:'easeIn'} }} exit={{opacity: 0}}>
+		<motion.div key={num.toString() + filter} initial={{opacity:0.0}} animate={{opacity:1, transition:{delay:(num) * 0.035, duration: 0.2, ease:'easeIn'} }} >
 		<Link to={`/listings/${listing?.id}`}>
 			<div className={`grid-item grid-item-${num}`} >
 				{/* IMPLEMENT SAVED LISTINGS LATER!!! AND BRING THIS HEART BACK!!! */}
@@ -26,7 +26,7 @@ export default function ListingsIndexCard ({distance, listing, num, filter}) {
 							<span className="index-rating-num">{formattedOverallRating()}</span>
 						</>
 					}</span></div>
-					{distance ? <p>{`${distance} miles away`}</p> : <p>Calculating distance...</p>}
+					{distance ? <p key={listing?.title}>{`${distance} miles away`}</p> : <p>Calculating distance...</p>}
 					{/* <p>{`${listing?.title}`}</p> */}
 					<p>June 15 - 22</p>
 					<div className="listings-index-price-para"><div className="listings-index-price-figure">{`$${listing?.baseNightlyRate}`}</div><div>&nbsp;night</div></div>


### PR DESCRIPTION
… after filter change. Fix issue: stale listing cards persist until fade animation completes while new listing cards already rendered, causing layout shift after stale cards complete fadeout and disappear