### PR TITLE
maintenance/listings: bugfix: filter change causing stale distances, layout shift in listings index

### DIFF
--- a/frontend/src/components/Listings/ListingsIndex.js
+++ b/frontend/src/components/Listings/ListingsIndex.js
@@ -40,6 +40,7 @@ const ListingsIndex = ({localLatLon, filter=null, isMapsAPILoaded}) => {
 
 	useEffect(() => {
 		window.scrollTo(0, 0);
+		setDistancesArray([]);
 	}, [filter])
 
 	let destinations = filteredListings.map(listing => {
@@ -82,30 +83,17 @@ const ListingsIndex = ({localLatLon, filter=null, isMapsAPILoaded}) => {
 	} else {
 		listingCards = [];
 		if(filteredListings.length !== 0){
-			if(!filter){
-				for(let i = 1; i <= numTestListings; i++) {
-					listingCards.push(
-						<ListingsIndexCard 
-							key={filteredListings[((i - 1) % filteredListings.length)].title}
-							distance={distancesArray[i - 1]} 
-							filter={filter} 
-							listing={filteredListings[(i - 1) % filteredListings.length]} 
-							num={i} 
-						/>
-					)
-				}
-			} else {
-				for(let i = 1; i <= filteredListings.length; i++) {
-					listingCards.push(
-						<ListingsIndexCard 
-							key={filteredListings[((i - 1) % filteredListings.length)].title}
-							distance={distancesArray[i - 1]} 
-							filter={filter} 
-							listing={filteredListings[(i - 1) % filteredListings.length]} 
-							num={i} 
-						/>
-					)
-				}
+			let limit = filter ? filteredListings.length : numTestListings;
+			for(let i = 1; i <= limit; i++) {
+				listingCards.push(
+					<ListingsIndexCard 
+						key={filteredListings[((i - 1) % filteredListings.length)].title}
+						distance={distancesArray[i - 1]} 
+						filter={filter} 
+						listing={filteredListings[(i - 1) % filteredListings.length]} 
+						num={i} 
+					/>
+				)
 			}
 		}
 	}

--- a/frontend/src/components/Listings/ListingsIndexCard.js
+++ b/frontend/src/components/Listings/ListingsIndexCard.js
@@ -9,7 +9,7 @@ export default function ListingsIndexCard ({distance, listing, num, filter}) {
 		return (twoDigit === oneDigit + '0') ? oneDigit : twoDigit;
 	}
 	return (
-		<motion.div key={num.toString() + filter} initial={{opacity:0.0}} animate={{opacity:1, transition:{delay:(num) * 0.035, duration: 0.2, ease:'easeIn'} }} exit={{opacity: 0}}>
+		<motion.div key={num.toString() + filter} initial={{opacity:0.0}} animate={{opacity:1, transition:{delay:(num) * 0.035, duration: 0.2, ease:'easeIn'} }} >
 		<Link to={`/listings/${listing?.id}`}>
 			<div className={`grid-item grid-item-${num}`} >
 				{/* IMPLEMENT SAVED LISTINGS LATER!!! AND BRING THIS HEART BACK!!! */}
@@ -26,7 +26,7 @@ export default function ListingsIndexCard ({distance, listing, num, filter}) {
 							<span className="index-rating-num">{formattedOverallRating()}</span>
 						</>
 					}</span></div>
-					{distance ? <p>{`${distance} miles away`}</p> : <p>Calculating distance...</p>}
+					{distance ? <p key={listing?.title}>{`${distance} miles away`}</p> : <p>Calculating distance...</p>}
 					{/* <p>{`${listing?.title}`}</p> */}
 					<p>June 15 - 22</p>
 					<div className="listings-index-price-para"><div className="listings-index-price-figure">{`$${listing?.baseNightlyRate}`}</div><div>&nbsp;night</div></div>


### PR DESCRIPTION
### Issue: layout shift in listings index
---

Upon changing listing category `filter`, filtered-out listings would persist while performing fadeout animation, while new listings would be immediately be appended to list. After completing fadeout, filtered-out listings would disappear from document flow, causing new listings to layout shift to intended positions.

Fixed by removing exit animation by removing the `exit` prop given to the `motion.div` wrapper in ListingsIndexCard JSX.
```js
// ListingsIndexCard.js
<motion.div key={num.toString() + filter} initial={{opacity:0.0}} animate={{opacity:1, transition:{delay:(num) * 0.035, duration: 0.2, ease:'easeIn'} }} >
```

### Issue: stale distances in listings index
---

While most likely unnoticeable to most users, throttling to slow networks showed stale distances would show on listing cards after changing `filter`. This was due to the `distancesArray` `useState` not being cleared while new distances were being asynchronously calculated whenever `filter` changed.

Fixed by clearing old distances whenever `filter` changes.
```js
useEffect(() => {
	window.scrollTo(0, 0);
	setDistancesArray([]);
}, [filter])
```